### PR TITLE
feat: implement filesystem trash mode for deletions

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -89,16 +89,24 @@ class KaloscopeConfig:
 
         When enabled, Python-type ScriptNode nodes restrict builtins
         to prevent risky operations (e.g. __import__, open, eval, exec).
-        Read from the `SCRIPT_STRICT_MODE` env var once at first access;
-        cached thereafter and cannot be changed for the server's lifetime.
-
-        Default is True (enabled). Only disabled when the env var is
-        explicitly set to "0", "no", "off", or "false".
 
         Returns:
             True if script strict mode is enabled, False otherwise.
         """
         value = os.environ.get("SCRIPT_STRICT_MODE", "").lower()
+        return value not in ("0", "no", "off", "false")
+
+    @cached_property
+    def filesystem_trash_mode(self) -> bool:
+        """Check if filesystem trash mode is enabled.
+
+        When enabled, filesystem deletes move paths to the OS trash
+        instead of permanently deleting them.
+
+        Returns:
+            True if filesystem trash mode is enabled, False otherwise.
+        """
+        value = os.environ.get("FILESYSTEM_TRASH_MODE", "").lower()
         return value not in ("0", "no", "off", "false")
 
     def configure(self, app: Sanic):

--- a/backend/app/core/media/watcher.py
+++ b/backend/app/core/media/watcher.py
@@ -10,7 +10,6 @@ from queue import Queue
 
 from sanic import Sanic
 from sanic.log import Colors, logger
-from send2trash import send2trash
 from tortoise.transactions import in_transaction
 from watchdog.events import (
     EVENT_TYPE_CREATED,
@@ -39,6 +38,7 @@ from app.models.media import MediaEvent, MediaItem, MediaLib
 from app.models.user import HistoryType, UserHistory
 from app.services.flow import FlowTriggerService
 from app.utils.crypto import encrypt
+from app.utils.disk import delete_path
 
 
 class EventHandler(FileSystemEventHandler):
@@ -462,10 +462,10 @@ async def _handle_deleted(event: MediaEvent):
     def _trash_nfo(path: str | None):
         if not path:
             return
-        # move the NFO file to the trash if it exists
+        # delete the NFO file according to filesystem trash mode
         nfo = Path(path)
         if nfo.exists() and nfo.is_file():
-            send2trash(nfo)
+            delete_path(nfo)
 
     lib_id = event.lib_id
     src_path = event.src_path

--- a/backend/app/services/flow.py
+++ b/backend/app/services/flow.py
@@ -10,7 +10,6 @@ import aiofiles
 import httpx
 from sanic.log import logger
 from sanic.request.form import File
-from send2trash import send2trash
 from tortoise import Tortoise, timezone
 from tortoise.expressions import Q
 from tortoise.transactions import atomic
@@ -38,6 +37,7 @@ from app.models.flow import (
 from app.models.user import HistoryType, PermType, UserHistory, UserPermission
 from app.services.base import BaseService
 from app.utils import json
+from app.utils.disk import delete_path
 
 
 class FlowRepositoryService(BaseService[FlowRepository], model=FlowRepository):
@@ -115,11 +115,11 @@ class FlowRepositoryService(BaseService[FlowRepository], model=FlowRepository):
         """
         repo = await FlowRepository.get(id=id)
         await repo.delete()
-        # move the repository directory to the trash if it exists
+        # delete the repository directory according to filesystem trash mode
         repo_dir = Path(KaloscopeConfig.get_workspace("repositories"))
         repo_path = repo_dir / repo.repo_name
         if repo_path.exists() and repo_path.is_dir():
-            send2trash(repo_path)
+            delete_path(repo_path)
 
 
 class FlowTemplateService(BaseService[FlowTemplate], model=FlowTemplate):

--- a/backend/app/services/media.py
+++ b/backend/app/services/media.py
@@ -5,7 +5,6 @@ from pathlib import Path
 import aiofiles
 from sanic import Sanic
 from sanic.log import logger
-from send2trash import send2trash
 from tortoise.expressions import Q
 from tortoise.transactions import atomic
 
@@ -16,6 +15,7 @@ from app.models.media import MediaItem, MediaLib, MediaLibUpsert, MediaMetadata,
 from app.models.user import PermType, UserPermission
 from app.services.base import BaseService
 from app.services.flow import FlowTriggerService
+from app.utils.disk import delete_path
 
 
 class MediaLibService(BaseService[MediaLib], model=MediaLib):
@@ -133,7 +133,7 @@ class MediaItemService(BaseService[MediaItem], model=MediaItem):
             item = await MediaItem.get(id=id)
             path = Path(item.path)
             if path.exists():
-                send2trash(path)
+                delete_path(path)
             await item.delete()
         else:
             await MediaItem.filter(id=id).update(visible=False)

--- a/backend/app/utils/disk.py
+++ b/backend/app/utils/disk.py
@@ -2,6 +2,10 @@ import shutil
 from dataclasses import dataclass
 from pathlib import Path
 
+from send2trash import send2trash
+
+from app.core.config import KaloscopeConfig
+
 
 @dataclass
 class DiskUsage:
@@ -66,6 +70,28 @@ def is_directory(path: Path | str) -> bool:
         return path.is_dir()
     except OSError:
         return False
+
+
+def delete_path(path: Path | str):
+    """Delete a filesystem path according to filesystem trash mode.
+
+    When filesystem trash mode is enabled, the path is moved to the OS trash.
+    When disabled, files and symlinks are unlinked and directories are removed.
+
+    Args:
+        path: The file or directory path to delete.
+    """
+    if not isinstance(path, Path):
+        path = Path(path)
+    if not path.exists() and not path.is_symlink():
+        return
+
+    if KaloscopeConfig.get().filesystem_trash_mode:
+        send2trash(path)
+    elif path.is_dir() and not path.is_symlink():
+        shutil.rmtree(path)
+    else:
+        path.unlink()
 
 
 def format_bytes(size_bytes: int) -> str:


### PR DESCRIPTION
Added a new delete_path function that respects the filesystem trash mode setting. When enabled, files are moved to the OS trash; otherwise, they are permanently deleted. Updated relevant code in media and flow services to utilize this new functionality.