### PR TITLE
feat: add cache control for frontend responses

### DIFF
--- a/backend/app/core/middleware.py
+++ b/backend/app/core/middleware.py
@@ -10,6 +10,16 @@ from app.core.constants import ENCODING, SESSION_ID, URL_PREFIX
 from app.core.exceptions import ErrorCode, UnauthorizedException
 from app.models.user import UserInfo, UserSession
 
+FRONTEND_NO_CACHE = "no-store, no-cache, must-revalidate, max-age=0"
+FRONTEND_NO_CACHE_PATHS = {
+    "/",
+    "/index.html",
+    "/404.html",
+    "/service-worker.js",
+    "/manifest.webmanifest",
+    "/_app/version.json",
+}
+
 
 async def on_request(request: Request):
     """The middleware for request.
@@ -62,6 +72,8 @@ async def on_response(request: Request, response) -> HTTPResponse | None:
     if not isinstance(response, HTTPResponse):
         return None
 
+    set_cache_headers(request, response)
+
     if 200 <= response.status < 300 and hasattr(request.ctx, "user"):
         # add the token to the response cookies
         user: UserInfo = request.ctx.user
@@ -91,6 +103,27 @@ async def on_response(request: Request, response) -> HTTPResponse | None:
         return wrapped
 
     return response
+
+
+def set_cache_headers(request: Request, response: HTTPResponse):
+    """Prevent stale frontend shells from surviving deployments.
+
+    Args:
+        request: The request object.
+        response: The response object.
+    """
+    if request.path.startswith(URL_PREFIX):
+        return
+
+    is_html = bool(
+        response.content_type and response.content_type.startswith("text/html")
+    )
+    if request.path not in FRONTEND_NO_CACHE_PATHS and not is_html:
+        return
+
+    response.headers["Cache-Control"] = FRONTEND_NO_CACHE
+    response.headers["Pragma"] = "no-cache"
+    response.headers["Expires"] = "0"
 
 
 class SessionHolder:

--- a/backend/tests/test_core_middleware.py
+++ b/backend/tests/test_core_middleware.py
@@ -1,0 +1,67 @@
+"""Unit tests for the core middleware."""
+
+import asyncio
+from types import SimpleNamespace
+from typing import Any
+
+from sanic import HTTPResponse
+from sanic.response import html, raw
+
+from app.core.constants import URL_PREFIX
+from app.core.middleware import on_response, set_cache_headers
+
+
+def _request(path: str) -> Any:
+    return SimpleNamespace(path=path, server_path=path, ctx=SimpleNamespace())
+
+
+def _run_response(path: str, response: HTTPResponse) -> HTTPResponse:
+    result = asyncio.run(on_response(_request(path), response))
+    assert result is not None
+    return result
+
+
+def test_html_no_cache():
+    """Frontend HTML must be revalidated after deployments."""
+    response = html("<!doctype html>")
+
+    result = _run_response("/", response)
+
+    assert result.headers["Cache-Control"] == (
+        "no-store, no-cache, must-revalidate, max-age=0"
+    )
+    assert result.headers["Pragma"] == "no-cache"
+    assert result.headers["Expires"] == "0"
+
+
+def test_pwa_files_no_cache():
+    """PWA update metadata must not be served stale by browser caches."""
+    response = raw(b"self.__WB_MANIFEST = []")
+
+    result = _run_response("/service-worker.js", response)
+
+    assert result.headers["Cache-Control"] == (
+        "no-store, no-cache, must-revalidate, max-age=0"
+    )
+
+
+def test_api_cache_unchanged():
+    """API responses should not receive frontend cache headers."""
+    response = html("<!doctype html>")
+
+    set_cache_headers(_request(f"{URL_PREFIX}/status"), response)
+
+    assert "Cache-Control" not in response.headers
+    assert "Pragma" not in response.headers
+    assert "Expires" not in response.headers
+
+
+def test_asset_cache_unchanged():
+    """Non-HTML frontend assets should not receive no-cache headers."""
+    response = raw(b"image")
+
+    result = _run_response("/logo.png", response)
+
+    assert "Cache-Control" not in result.headers
+    assert "Pragma" not in result.headers
+    assert "Expires" not in result.headers

--- a/backend/tests/test_core_renderer.py
+++ b/backend/tests/test_core_renderer.py
@@ -1,3 +1,5 @@
+"""Unit tests for the core renderer."""
+
 from app.core.renderer import ENV, query_param, render
 
 


### PR DESCRIPTION
Implement cache control headers to prevent stale frontend shells after deployments. Added unit tests to ensure HTML and PWA update files are not cached by browsers.