### PR TITLE
feat: add magnet link copy functionality for downloads

### DIFF
--- a/frontend/src/lib/icons/$icons.ts
+++ b/frontend/src/lib/icons/$icons.ts
@@ -1246,6 +1246,16 @@ export const icons: Readonly<{ [key in keyof typeof names]: IconifyIcon }> = {
     hFlip: false,
     body: '<g fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5"><path d="M14.186 2.753v3.596c0 .487.194.955.54 1.3a1.85 1.85 0 0 0 1.306.539h4.125"/><path d="M20.25 8.568v8.568a4.25 4.25 0 0 1-1.362 2.97a4.28 4.28 0 0 1-3.072 1.14h-7.59a4.3 4.3 0 0 1-3.1-1.124a4.26 4.26 0 0 1-1.376-2.986V6.862a4.25 4.25 0 0 1 1.362-2.97a4.28 4.28 0 0 1 3.072-1.14h5.714a3.5 3.5 0 0 1 2.361.905l2.96 2.722a2.97 2.97 0 0 1 1.031 2.189"/><path d="m8.36 13.682l1.879 1.88a.71.71 0 0 0 1.01 0l3.787-3.787"/></g>'
   },
+  magnetUp: {
+    left: 0,
+    top: 0,
+    width: 24,
+    height: 24,
+    rotate: 0,
+    vFlip: false,
+    hFlip: false,
+    body: '<path fill="none" stroke="currentColor" stroke-width="1.5" d="M20.696 3.837v8.404a8.893 8.893 0 0 1-8.12 8.99a8.7 8.7 0 0 1-9.273-8.697V3.837A1.087 1.087 0 0 1 4.39 2.75h3.26a1.087 1.087 0 0 1 1.087 1.087v8.697a3.261 3.261 0 1 0 6.523 0V3.837a1.087 1.087 0 0 1 1.087-1.087h3.261a1.087 1.087 0 0 1 1.087 1.087ZM8.738 9.273H3.303m17.393 0h-5.435"/>'
+  },
   pinFill: {
     left: 0,
     top: 0,

--- a/frontend/src/lib/icons/icons.ts
+++ b/frontend/src/lib/icons/icons.ts
@@ -138,6 +138,7 @@ const mageIcons = {
   edit: 'mage:edit',
   externalLink: 'mage:external-link',
   fileCheck: 'mage:file-check',
+  magnetUp: 'mage:magnet-up',
   pinFill: 'mage:pin-fill',
   stars: 'mage:stars-c',
   user: 'mage:user',

--- a/frontend/src/lib/locales/en-US.json
+++ b/frontend/src/lib/locales/en-US.json
@@ -131,6 +131,7 @@
   "field": {
     "dir": "Directory",
     "file": "File",
+    "link": "Link",
     "type": "Type",
     "name": "Name",
     "size": "Size",
@@ -722,6 +723,7 @@
     "invalid_yaml_config": "Invalid YAML configuration!",
     "invalid_github_repo": "Invalid GitHub repository!",
     "invalid_flow_graph": "Not all required fields are filled!",
+    "magnet_link_copied": "Magnet link copied!",
     "info_hash_collision": "Download already exists!",
     "get_info_hash_failed": "Failed to get info-hash!",
     "http_request_failed": "HTTP request failed!",

--- a/frontend/src/lib/locales/zh-CN.json
+++ b/frontend/src/lib/locales/zh-CN.json
@@ -131,6 +131,7 @@
   "field": {
     "dir": "目录",
     "file": "文件",
+    "link": "链接",
     "type": "类型",
     "name": "名称",
     "size": "大小",
@@ -722,6 +723,7 @@
     "invalid_yaml_config": "无效的 YAML 配置！",
     "invalid_github_repo": "无效的 GitHub 仓库！",
     "invalid_flow_graph": "必填字段未填写完整！",
+    "magnet_link_copied": "磁力链接已复制！",
     "info_hash_collision": "下载任务已存在！",
     "get_info_hash_failed": "获取哈希值失败！",
     "http_request_failed": "发送 HTTP 请求失败！",

--- a/frontend/src/routes/(app)/downloads/completed/+page.svelte
+++ b/frontend/src/routes/(app)/downloads/completed/+page.svelte
@@ -26,6 +26,7 @@
   let downloaders: Downloader[] = $state([]);
   let deleteConfirm: DownloadDelConfirm;
   let headerCheckbox: Checkbox;
+  let navigatorClipboard = $state(false);
 
   const pagination: PaginatorProps = $state({ current: 1, size: 50, onchange: search });
   const ordering = createSortField();
@@ -103,12 +104,30 @@
     deleteConfirm.showModal(ids);
   }
 
+  /**
+   * Copy the magnet link of a download task.
+   *
+   * @param task - The download task.
+   */
+  async function copyMagnetLink(task: DownloadTask) {
+    if (!task.magnet_link || !navigator.clipboard) {
+      return;
+    }
+    try {
+      await navigator.clipboard.writeText(task.magnet_link);
+      alert({ level: 'success', message: 'magnet_link_copied' });
+    } catch {
+      return;
+    }
+  }
+
   $effect(() => {
     $ordering; // eslint-disable-line
     untrack(() => search());
   });
 
   onMount(() => {
+    navigatorClipboard = !!navigator.clipboard;
     api
       .get('download/manager/list')
       .json<Resp<Downloader[]>>()
@@ -173,6 +192,12 @@
     </Cell>
     <Cell
       actions={[
+        {
+          condition: !!task.magnet_link && navigatorClipboard,
+          icon: icons.magnetUp,
+          text: $_('action.copy', $_('field.link')),
+          onclick: () => copyMagnetLink(task)
+        },
         {
           icon: icons.delete,
           text: $_('action.delete', $_('entity.task')),

--- a/frontend/src/routes/(app)/downloads/downloading/+page.svelte
+++ b/frontend/src/routes/(app)/downloads/downloading/+page.svelte
@@ -29,6 +29,7 @@
   let downloaders: Downloader[] = $state([]);
   let deleteConfirm: DownloadDelConfirm;
   let headerCheckbox: Checkbox;
+  let navigatorClipboard = $state(false);
 
   const pagination: PaginatorProps = $state({ current: 1, size: 50, onchange: search });
   const ordering = createSortField();
@@ -153,12 +154,30 @@
       });
   }
 
+  /**
+   * Copy the magnet link of a download task.
+   *
+   * @param task - The download task.
+   */
+  async function copyMagnetLink(task: DownloadTask) {
+    if (!task.magnet_link || !navigator.clipboard) {
+      return;
+    }
+    try {
+      await navigator.clipboard.writeText(task.magnet_link);
+      alert({ level: 'success', message: 'magnet_link_copied' });
+    } catch {
+      return;
+    }
+  }
+
   $effect(() => {
     $ordering; // eslint-disable-line
     untrack(() => search());
   });
 
   onMount(() => {
+    navigatorClipboard = !!navigator.clipboard;
     api
       .get('download/manager/list')
       .json<Resp<Downloader[]>>()
@@ -257,6 +276,12 @@
           icon: icons.playFilled,
           text: $_('action.start', $_('entity.task')),
           onclick: () => start(task)
+        },
+        {
+          condition: !!task.magnet_link && navigatorClipboard,
+          icon: icons.magnetUp,
+          text: $_('action.copy', $_('field.link')),
+          onclick: () => copyMagnetLink(task)
         },
         {
           icon: icons.delete,


### PR DESCRIPTION
- Implemented a feature to copy the magnet link of a download task to the clipboard.
- Added a new icon for the copy action and updated the UI accordingly.
- Included localization for the success message upon copying the link.