### PR TITLE
feat(media): 添加与元数据源无关的剧集名称解析能力

### DIFF
--- a/backend/app/utils/extractor.py
+++ b/backend/app/utils/extractor.py
@@ -1,8 +1,64 @@
 """Media filename metadata extraction utilities."""
 
+import hashlib
 import re
+import unicodedata
+from dataclasses import dataclass
+from decimal import Decimal, InvalidOperation
+from enum import StrEnum
+
+import opencc
 
 from app.utils.numeral import cn_to_int
+
+
+class EpisodeKind(StrEnum):
+    """Provider-independent kinds of episodic media."""
+
+    REGULAR = "regular"
+    SPECIAL = "special"
+    OVA = "ova"
+    OAD = "oad"
+    ONA = "ona"
+    NCOP = "ncop"
+    NCED = "nced"
+    PV = "pv"
+    TRAILER = "trailer"
+    CM = "cm"
+    OTHER = "other"
+
+
+@dataclass(frozen=True, slots=True)
+class EpisodeRef:
+    """A canonical episode reference parsed from a media name."""
+
+    kind: EpisodeKind
+    number: Decimal
+    absolute_number: Decimal | None = None
+
+    @property
+    def canonical_number(self) -> str:
+        """Return a stable, non-exponential representation of the number."""
+        return _canonical_decimal(self.number)
+
+
+@dataclass(frozen=True, slots=True)
+class ParsedMediaName:
+    """Structured metadata extracted from a media or release name."""
+
+    raw_name: str
+    title: str
+    normalized_title: str
+    year: int | None
+    season: int | None
+    episodes: tuple[EpisodeRef, ...]
+    release_version: int | None
+    is_batch: bool
+    context_source: str
+    confidence: str
+
+
+_T2S_CONVERTER = opencc.OpenCC("t2s.json")
 
 # pattern to match common separators: dot, underscore, hyphen, space, star
 _SEPARATOR_PATTERN = re.compile(r"[._\-\s★☆]+")
@@ -87,7 +143,7 @@ _EPISODE_PATTERN = re.compile(
         | \s-\s(?!0*(?:19|20)\d{2}\b)0*(\d{1,4})\s*
           (?:[Ee][Nn][Dd]\b\s*)?(?:-|[\[\(]|$)
         | \[(?!(?:19|20)\d{2}\])0*(\d{1,4})
-          (?:[Vv][2-9]|\s*-\s*(?:\d{1,4}|[总總]第\s*(?:\d{1,4}|[零一二三四五六七八九十百千]+)))?\]
+          (?:[Vv]\d+|\s*-\s*(?:\d{1,4}|[总總]第\s*(?:\d{1,4}|[零一二三四五六七八九十百千]+)))?\]
         | 第\s*(\d{1,4})\s*[集话話回](?=$|[\s\]\)】\[\(【._-])
         | 第\s*([零一二三四五六七八九十百千]+)\s*[集话話回](?=$|[\s\]\)】\[\(【._-])
     )
@@ -179,6 +235,247 @@ _ENGLISH_ORDINAL_NUMBERS = {
     "tenth": 10,
 }
 
+_DECIMAL_TOKEN = r"\d{1,4}(?:\.\d{1,2}(?!\d))?"
+_NUMBER_SUFFIX_GUARD = r"(?![\dA-Za-z])"
+
+_ABSOLUTE_EPISODE_PATTERN = re.compile(
+    rf"(?P<local>{_DECIMAL_TOKEN})\s*-\s*[总總]\s*第?\s*"
+    rf"(?P<absolute>{_DECIMAL_TOKEN}){_NUMBER_SUFFIX_GUARD}",
+    re.IGNORECASE,
+)
+_TYPED_EPISODE_PATTERN = re.compile(
+    rf"""
+    (?<![A-Za-z0-9])
+    (?P<label>
+        NCOP|NCED|OVA|OAD|ONA|SP|SPECIAL|PV|TRAILER|CM|OP|ED
+        | 特别篇|特別篇|特典|番外(?:篇)?|总集篇|總集篇
+    )
+    (?=$|[^A-Za-z]|\d)
+    (?:[\s._\-\[\]()【】]*
+       (?P<start>{_DECIMAL_TOKEN})(?![\dA-Za-z]))?
+    (?:\s*[-~～]\s*(?:(?P=label)[\s._\-]*)?
+       (?P<end>{_DECIMAL_TOKEN})(?![\dA-Za-z]))?
+    """,
+    re.IGNORECASE | re.VERBOSE,
+)
+_SEASON_EPISODE_PATTERN = re.compile(
+    rf"(?<![A-Za-z0-9])[Ss](?P<season>\d{{1,3}})[Ee]"
+    rf"(?P<start>{_DECIMAL_TOKEN})(?!\d)"
+    rf"(?:\s*[-~～]\s*[Ee]?(?P<end>{_DECIMAL_TOKEN})(?!\d)"
+    rf"|[Ee](?P<next>{_DECIMAL_TOKEN})(?!\d))?",
+    re.IGNORECASE,
+)
+_EXPLICIT_EPISODE_PATTERN = re.compile(
+    rf"(?<![A-Za-z0-9])[Ee][Pp]?\.?\s*"
+    rf"(?P<start>{_DECIMAL_TOKEN})(?!\d)"
+    rf"(?:\s*[-~～]\s*[Ee]?[Pp]?\.?(?P<end>{_DECIMAL_TOKEN})(?!\d))?"
+    rf"(?:\s*(?:END|FIN)\b)?"
+    rf"(?:\s*[\[【(][^\]】)]*[\]】)])?",
+    re.IGNORECASE,
+)
+_CHINESE_EPISODE_PATTERN = re.compile(
+    rf"第\s*(?P<start>{_DECIMAL_TOKEN})\s*"
+    rf"(?:[-~～]\s*(?P<end>{_DECIMAL_TOKEN})\s*)?[集话話回]",
+)
+_BRACKET_EPISODE_PATTERN = re.compile(
+    rf"[\[【(]\s*(?P<start>{_DECIMAL_TOKEN})"
+    rf"(?:\s*[-~～]\s*(?P<end>{_DECIMAL_TOKEN}))?"
+    rf"(?:[Vv](?P<version>\d+))?\s*(?:合集)?\s*[\]】)]",
+    re.IGNORECASE,
+)
+_DASH_EPISODE_PATTERN = re.compile(
+    rf"\s-\s(?P<start>{_DECIMAL_TOKEN})(?!\d)"
+    rf"(?:\s*[-~～]\s*(?P<end>{_DECIMAL_TOKEN})(?!\d))?"
+    rf"(?=\s*(?:END\b|FIN\b|[\[【(]|-|$))",
+    re.IGNORECASE,
+)
+_PIPE_RANGE_PATTERN = re.compile(
+    rf"\|\s*(?P<start>{_DECIMAL_TOKEN})\s*[-~～]\s*"
+    rf"(?P<end>{_DECIMAL_TOKEN})(?!\d)",
+)
+_RELEASE_VERSION_PATTERN = re.compile(r"(?<![A-Za-z])[Vv](\d+)(?!\d)")
+_BATCH_PATTERN = re.compile(r"合集|全集|全\s*\d+\s*[集话話回]|\b(?:batch|complete)\b", re.I)
+_END_MARKER_PATTERN = re.compile(r"\b(?:END|FIN)\b", re.IGNORECASE)
+
+_TYPE_LABELS = {
+    "sp": EpisodeKind.SPECIAL,
+    "special": EpisodeKind.SPECIAL,
+    "特别篇": EpisodeKind.SPECIAL,
+    "特別篇": EpisodeKind.SPECIAL,
+    "特典": EpisodeKind.SPECIAL,
+    "番外": EpisodeKind.SPECIAL,
+    "番外篇": EpisodeKind.SPECIAL,
+    "总集篇": EpisodeKind.SPECIAL,
+    "總集篇": EpisodeKind.SPECIAL,
+    "ova": EpisodeKind.OVA,
+    "oad": EpisodeKind.OAD,
+    "ona": EpisodeKind.ONA,
+    "ncop": EpisodeKind.NCOP,
+    "op": EpisodeKind.NCOP,
+    "nced": EpisodeKind.NCED,
+    "ed": EpisodeKind.NCED,
+    "pv": EpisodeKind.PV,
+    "trailer": EpisodeKind.TRAILER,
+    "cm": EpisodeKind.CM,
+}
+
+
+def _canonical_decimal(value: Decimal) -> str:
+    text = format(value, "f")
+    if "." in text:
+        text = text.rstrip("0").rstrip(".")
+    return text or "0"
+
+
+def _parse_decimal(value: str | None) -> Decimal | None:
+    if value is None:
+        return None
+    try:
+        return Decimal(value).normalize()
+    except InvalidOperation:
+        return None
+
+
+def _episode_values(start: Decimal, end: Decimal | None) -> tuple[Decimal, ...]:
+    if end is None or end == start:
+        return (start,)
+    if start == start.to_integral() and end == end.to_integral():
+        step = 1 if end > start else -1
+        values = range(int(start), int(end) + step, step)
+        return tuple(Decimal(value) for value in values)
+    # Decimal episode numbers are labels, not an arithmetic sequence.
+    return (start, end)
+
+
+def _structured_episodes(name: str) -> tuple[EpisodeRef, ...]:
+    episodes: dict[tuple[EpisodeKind, Decimal], EpisodeRef] = {}
+
+    def add(
+        kind: EpisodeKind,
+        start_text: str | None,
+        end_text: str | None = None,
+        *,
+        absolute_text: str | None = None,
+    ) -> None:
+        start = _parse_decimal(start_text)
+        if start is None:
+            start = Decimal(1)
+        end = _parse_decimal(end_text)
+        absolute = _parse_decimal(absolute_text)
+        for offset, number in enumerate(_episode_values(start, end)):
+            absolute_number = absolute
+            if absolute is not None and number == number.to_integral():
+                absolute_number = absolute + offset
+            key = (kind, number)
+            current = episodes.get(key)
+            if current is None or (
+                current.absolute_number is None and absolute_number is not None
+            ):
+                episodes[key] = EpisodeRef(kind, number, absolute_number)
+
+    for match in _ABSOLUTE_EPISODE_PATTERN.finditer(name):
+        add(
+            EpisodeKind.REGULAR,
+            match.group("local"),
+            absolute_text=match.group("absolute"),
+        )
+
+    for match in _TYPED_EPISODE_PATTERN.finditer(name):
+        label = match.group("label").casefold()
+        add(
+            _TYPE_LABELS.get(label, EpisodeKind.OTHER),
+            match.group("start"),
+            match.group("end"),
+        )
+
+    for pattern in (
+        _SEASON_EPISODE_PATTERN,
+        _EXPLICIT_EPISODE_PATTERN,
+        _CHINESE_EPISODE_PATTERN,
+        _BRACKET_EPISODE_PATTERN,
+        _DASH_EPISODE_PATTERN,
+        _PIPE_RANGE_PATTERN,
+    ):
+        for match in pattern.finditer(name):
+            start = match.groupdict().get("start")
+            looks_like_year = (
+                start
+                and len(start.split(".", 1)[0]) == 4
+                and start.startswith(("19", "20"))
+            )
+            if looks_like_year:
+                continue
+            end = match.groupdict().get("end") or match.groupdict().get("next")
+            add(EpisodeKind.REGULAR, start, end)
+
+    # An explicit regular token (for example S01E00 Special) is stronger than
+    # an unnumbered descriptive extra label.
+    if any(ref.kind == EpisodeKind.REGULAR for ref in episodes.values()):
+        for match in _TYPED_EPISODE_PATTERN.finditer(name):
+            if match.group("start") is None:
+                label = match.group("label").casefold()
+                kind = _TYPE_LABELS.get(label, EpisodeKind.OTHER)
+                episodes.pop((kind, Decimal(1)), None)
+
+    return tuple(episodes.values())
+
+
+def normalize_series_title(title: str) -> str:
+    """Normalize a local series title without fuzzy or provider-based matching."""
+    normalized = unicodedata.normalize("NFKC", title)
+    normalized = _T2S_CONVERTER.convert(normalized).casefold()
+    chars = [ch if ch.isalnum() else " " for ch in normalized]
+    return " ".join("".join(chars).split())
+
+
+def parse_media_name(
+    name: str,
+    *,
+    series_title: str | None = None,
+    year: int | None = None,
+    season: int | None = None,
+) -> ParsedMediaName:
+    """Parse a media name into provider-independent structured metadata."""
+    context_name = series_title if series_title is not None else name
+    parsed_title = extract_title(context_name)
+    parsed_year = year if year is not None else extract_year(context_name)
+    parsed_season = season if season is not None else extract_season(context_name)
+    if parsed_season is None and series_title is not None:
+        parsed_season = extract_season(name)
+
+    versions = [
+        int(match.group(1)) for match in _RELEASE_VERSION_PATTERN.finditer(name)
+    ]
+    provided_context = series_title is not None
+    episodes = _structured_episodes(name)
+    return ParsedMediaName(
+        raw_name=name,
+        title=parsed_title,
+        normalized_title=normalize_series_title(parsed_title),
+        year=parsed_year,
+        season=parsed_season,
+        episodes=episodes,
+        release_version=max(versions, default=None),
+        is_batch=bool(_BATCH_PATTERN.search(name)) or len(episodes) > 1,
+        context_source="provided" if provided_context else "inferred",
+        confidence="high" if provided_context else "low",
+    )
+
+
+def build_local_episode_keys(parsed: ParsedMediaName) -> tuple[str, ...]:
+    """Build deterministic local episode keys from structured parsed metadata."""
+    if not parsed.normalized_title:
+        return ()
+    year = str(parsed.year) if parsed.year is not None else "_"
+    payload = f"title={parsed.normalized_title}|year={year}"
+    series_hash = hashlib.sha256(payload.encode("utf-8")).hexdigest()
+    season = str(parsed.season) if parsed.season is not None else "_"
+    return tuple(
+        f"local:v1:{series_hash}:s{season}:{episode.kind.value}:"
+        f"{episode.canonical_number}"
+        for episode in parsed.episodes
+    )
+
 
 def extract_year(name: str) -> int | None:
     """Extract the release year from a media file name.
@@ -223,6 +520,13 @@ def extract_episode(name: str) -> int | None:
     Returns:
         The episode number as an integer, or None if not found.
     """
+    for episode in _structured_episodes(name):
+        if episode.kind != EpisodeKind.REGULAR:
+            continue
+        if episode.number != episode.number.to_integral():
+            return None
+        return int(episode.number)
+
     match = _EPISODE_PATTERN.search(name)
     if match:
         value = next(g for g in match.groups() if g is not None)
@@ -252,6 +556,24 @@ def extract_title(name: str) -> str:
 
     # remove standalone year token before video tags
     title = _YEAR_PATTERN.sub(" ", title)
+
+    # remove collection ranges before their component episode tokens
+    title = _COLLECTION_RANGE_PATTERN.sub(" ", title)
+
+    # remove structured episode markers, including decimals and typed extras
+    for pattern in (
+        _ABSOLUTE_EPISODE_PATTERN,
+        _TYPED_EPISODE_PATTERN,
+        _SEASON_EPISODE_PATTERN,
+        _EXPLICIT_EPISODE_PATTERN,
+        _CHINESE_EPISODE_PATTERN,
+        _BRACKET_EPISODE_PATTERN,
+        _DASH_EPISODE_PATTERN,
+        _PIPE_RANGE_PATTERN,
+    ):
+        title = pattern.sub(" ", title)
+    title = _RELEASE_VERSION_PATTERN.sub(" ", title)
+    title = _END_MARKER_PATTERN.sub(" ", title)
 
     # remove collection episode ranges before technical tags truncate context
     title = _COLLECTION_RANGE_PATTERN.sub(" ", title)

--- a/backend/tests/test_utils_extractor.py
+++ b/backend/tests/test_utils_extractor.py
@@ -1,10 +1,16 @@
 """Unit tests for the media keyword extractor utility."""
 
+from decimal import Decimal
+
 from app.utils.extractor import (
+    EpisodeKind,
+    build_local_episode_keys,
     extract_episode,
     extract_season,
     extract_title,
     extract_year,
+    normalize_series_title,
+    parse_media_name,
 )
 
 
@@ -137,7 +143,7 @@ class TestExtractEpisode:
         assert extract_episode("Show [16v2][WebRip]") == 16
         assert extract_episode("Show [16v4][WebRip]") == 16
         assert extract_episode("Show [16v9][WebRip]") == 16
-        assert extract_episode("Show [16v10][WebRip]") is None
+        assert extract_episode("Show [16v10][WebRip]") == 16
 
     def test_chinese_episode_ji(self):
         assert extract_episode("庆余年 第3集") == 3
@@ -176,6 +182,9 @@ class TestExtractEpisode:
 
     def test_bracketed_year_not_episode(self):
         assert extract_episode("Movie.Title.[2023]") is None
+
+    def test_decimal_requires_structured_parser(self):
+        assert extract_episode("Show - 12.5 [1080p]") is None
 
 
 class TestExtractTitle:
@@ -527,3 +536,170 @@ class TestExtractTitle:
     def test_returns_string(self):
         assert extract_title("[Group] 2023 1080p S01E01")
         assert isinstance(extract_title(""), str)
+
+
+class TestParseMediaName:
+    @staticmethod
+    def refs(parsed):
+        return [
+            (ref.kind, ref.canonical_number, ref.absolute_number)
+            for ref in parsed.episodes
+        ]
+
+    def test_decimal_episode(self):
+        parsed = parse_media_name("Example Show - 12.50 [1080p]")
+        assert self.refs(parsed) == [(EpisodeKind.REGULAR, "12.5", None)]
+        assert parsed.title == "Example Show"
+
+    def test_season_episode_range_expands_all_episodes(self):
+        parsed = parse_media_name("Example.Show.S01E01-E03.1080p")
+        assert self.refs(parsed) == [
+            (EpisodeKind.REGULAR, "1", None),
+            (EpisodeKind.REGULAR, "2", None),
+            (EpisodeKind.REGULAR, "3", None),
+        ]
+        assert parsed.is_batch is True
+
+    def test_decimal_range_does_not_invent_intermediate_labels(self):
+        parsed = parse_media_name("Example Show E12.5-E13.5")
+        assert [ref.canonical_number for ref in parsed.episodes] == ["12.5", "13.5"]
+
+    def test_typed_range_expands_all_extras(self):
+        parsed = parse_media_name("Example Show SP01-SP03")
+        assert [(ref.kind, ref.number) for ref in parsed.episodes] == [
+            (EpisodeKind.SPECIAL, Decimal(1)),
+            (EpisodeKind.SPECIAL, Decimal(2)),
+            (EpisodeKind.SPECIAL, Decimal(3)),
+        ]
+
+    def test_consecutive_episode_tokens(self):
+        parsed = parse_media_name("Example Show S01E01E02")
+        assert [ref.number for ref in parsed.episodes] == [Decimal(1), Decimal(2)]
+
+    def test_bracketed_batch_range(self):
+        parsed = parse_media_name("Example Show [01-03 合集][1080p]")
+        assert [ref.number for ref in parsed.episodes] == [
+            Decimal(1),
+            Decimal(2),
+            Decimal(3),
+        ]
+        assert parsed.is_batch is True
+
+    def test_chinese_episode_range(self):
+        parsed = parse_media_name("示例动画 第01-03話 [1080p]")
+        assert [ref.number for ref in parsed.episodes] == [
+            Decimal(1),
+            Decimal(2),
+            Decimal(3),
+        ]
+
+    def test_absolute_episode_number(self):
+        parsed = parse_media_name("[Show][10 - 总第76][WEB-DL]")
+        regular = [ref for ref in parsed.episodes if ref.kind == EpisodeKind.REGULAR]
+        assert len(regular) == 1
+        assert regular[0].number == Decimal(10)
+        assert regular[0].absolute_number == Decimal(76)
+
+    def test_release_version_is_not_episode_identity(self):
+        parsed = parse_media_name("Example Show [16v12][WebRip]")
+        assert parsed.release_version == 12
+        assert self.refs(parsed) == [(EpisodeKind.REGULAR, "16", None)]
+
+    def test_context_overrides_release_title_and_season(self):
+        parsed = parse_media_name(
+            "Wrong.Release.Name.S09E02.1080p",
+            series_title="Example Show (2024)",
+            year=2024,
+            season=2,
+        )
+        assert parsed.title == "Example Show"
+        assert parsed.year == 2024
+        assert parsed.season == 2
+        assert parsed.context_source == "provided"
+        assert parsed.confidence == "high"
+
+    def test_filename_fallback_is_low_confidence(self):
+        parsed = parse_media_name("Example.Show.S01E02.1080p")
+        assert parsed.context_source == "inferred"
+        assert parsed.confidence == "low"
+
+    def test_year_resolution_checksum_and_codec_are_not_episodes(self):
+        for name in (
+            "Movie.Title.2023.1080p",
+            "Movie.Title.2160p.[A1B2C3D4]",
+            "Daily Show 2026.07.12 1080p",
+            "Example Show OPUS 1080p",
+            "Doraemon1979 HDTV",
+        ):
+            assert parse_media_name(name).episodes == ()
+
+    def test_episode_kinds_are_classified(self):
+        cases = {
+            "Show SP01": EpisodeKind.SPECIAL,
+            "Show 特别篇 01": EpisodeKind.SPECIAL,
+            "Show OVA01": EpisodeKind.OVA,
+            "Show OAD01": EpisodeKind.OAD,
+            "Show ONA01": EpisodeKind.ONA,
+            "Show NCOP": EpisodeKind.NCOP,
+            "Show NCED2": EpisodeKind.NCED,
+            "Show PV2": EpisodeKind.PV,
+            "Show Trailer": EpisodeKind.TRAILER,
+            "Show CM3": EpisodeKind.CM,
+        }
+        for name, kind in cases.items():
+            parsed = parse_media_name(name)
+            assert parsed.episodes[0].kind == kind
+
+    def test_typed_extra_without_number_defaults_to_one(self):
+        parsed = parse_media_name("Example Show OVA")
+        assert self.refs(parsed) == [(EpisodeKind.OVA, "1", None)]
+
+    def test_same_number_different_kinds_get_different_keys(self):
+        regular = parse_media_name("Show E01", series_title="Show", season=1)
+        special = parse_media_name("Show SP01", series_title="Show", season=1)
+        ova = parse_media_name("Show OVA01", series_title="Show", season=1)
+        keys = {
+            build_local_episode_keys(regular)[0],
+            build_local_episode_keys(special)[0],
+            build_local_episode_keys(ova)[0],
+        }
+        assert len(keys) == 3
+
+
+class TestLocalEpisodeIdentity:
+    def test_title_normalization(self):
+        assert normalize_series_title("  ＥＸＡＭＰＬＥ・Show！ ") == "example show"
+        assert normalize_series_title("繁體中文") == normalize_series_title("繁体中文")
+
+    def test_key_is_deterministic_across_title_formatting(self):
+        first = parse_media_name(
+            "Release E01", series_title="Example.Show", year=2024, season=1
+        )
+        second = parse_media_name(
+            "Other E01", series_title="Ｅｘａｍｐｌｅ Show", year=2024, season=1
+        )
+        assert build_local_episode_keys(first) == build_local_episode_keys(second)
+
+    def test_year_and_season_separate_identities(self):
+        base = parse_media_name("E01", series_title="Show", year=2024, season=1)
+        remake = parse_media_name("E01", series_title="Show", year=2025, season=1)
+        next_season = parse_media_name(
+            "E01", series_title="Show", year=2024, season=2
+        )
+        assert build_local_episode_keys(base) != build_local_episode_keys(remake)
+        assert build_local_episode_keys(base) != build_local_episode_keys(next_season)
+
+    def test_release_version_does_not_change_key(self):
+        original = parse_media_name(
+            "Show [01][1080p]", series_title="Show", year=2024, season=1
+        )
+        revision = parse_media_name(
+            "Show [01v10][1080p]", series_title="Show", year=2024, season=1
+        )
+        assert build_local_episode_keys(original) == build_local_episode_keys(revision)
+
+    def test_batch_builds_one_key_per_episode(self):
+        parsed = parse_media_name(
+            "Show [01-12 合集]", series_title="Show", year=2024, season=1
+        )
+        assert len(build_local_episode_keys(parsed)) == 12


### PR DESCRIPTION
## 概述

本 PR 新增结构化媒体名称解析器，以及不依赖外部元数据网站的本地剧集唯一标识。

本次修改属于基础能力建设

其目的是先解决“一个下载资源对应哪部作品、哪一集”的问题，为后续实现“同一集只下载一次”的下载计划查重功能提供可靠前置条件。

## 背景

Kaloscope 目前通过 BitTorrent v1/v2 哈希进行下载查重。这可以避免同一个种子被重复提交，但无法判断不同发布资源是否对应同一集，例如：

```text
[字幕组 A] 示例动画 - 03 [1080p]
[字幕组 B] 示例动画 - 03 [2160p]
Example.Show.S01E03.REPACK
```

这些资源拥有不同的种子哈希，但在语义上都对应：

```text
示例动画
第 1 季
正片第 3 集
```

因此，在实现下载计划的持久化记忆和重复下载拦截之前，系统需要先稳定回答：

> 这个发布资源对应哪部作品、哪个季度、哪种剧集以及第几集？

如果完全依赖 Bangumi、TMDB 等外部元数据网站，那么未收录作品或未收录剧集将无法参与查重。

本 PR 因此提供一套本地剧集身份机制，使作品即使没有被外部网站收录，也可以完成解析和去重。

这是后续下载计划查重功能的前置 PR。

## 主要改动

### 新增结构化解析接口

现有接口保持不变：

```python
extract_title()
extract_year()
extract_season()
extract_episode()
```

新增统一解析接口：

```python
parse_media_name(
    name,
    *,
    series_title=None,
    year=None,
    season=None,
)
```

该接口返回 `ParsedMediaName`，其中包含：

- 清理后的作品标题；
- 标准化作品标题；
- 年份；
- 季度；
- 当前资源覆盖的全部剧集；
- 剧集类型；
- 可选的绝对集数；
- 发布修订版本；
- 是否为合集或多集资源；
- 作品上下文是外部提供还是从文件名推断；
- 身份信息可信度。

每个解析出的剧集使用 `EpisodeRef` 表示。

### 剧集类型

新增与元数据网站无关的 `EpisodeKind`：

- `regular`：普通正片
- `special`：特别篇
- `ova`
- `oad`
- `ona`
- `ncop`
- `nced`
- `pv`
- `trailer`
- `cm`
- `other`

不同类型不会共享同一个剧集标识，例如：

```text
E01
SP01
OVA01
```

会生成三个不同的本地剧集标识。

### 扩展剧集编号解析能力

结构化解析器现在支持以下格式。

普通整数集数：

```text
E03
EP03
S01E03
第3集
```

小数集数：

```text
12.5
E12.5
```

多集资源：

```text
S01E01-E03
S01E01E02
```

中文及括号范围：

```text
第01-03話
[01-12 合集]
```

附加内容：

```text
SP01
OVA01
OAD01
ONA01
NCOP
NCED2
PV2
```

绝对集数：

```text
[10 - 总第76]
```

多位发布修订版本：

```text
v10
v12
```

整数范围会展开成完整覆盖集。例如：

```text
S01E01-E03
```

会解析为第 1、2、3 集，而不是只保存起止端点。

这样，未来下载一个合集后，可以一次性占用其覆盖的全部剧集标识。

对于小数范围，只记录标题中明确出现的端点，不自动推测中间不存在的小数集。

### 本地剧集唯一标识

新增 `normalize_series_title()`，使用以下规则对作品标题进行保守归一化：

- Unicode NFKC 归一化；
- 使用项目已有的 OpenCC 依赖进行繁体转简体；
- Unicode 大小写折叠；
- 标点符号归一化；
- 空白字符归一化。

新增 `build_local_episode_keys()`，根据以下信息生成带版本的确定性本地标识：

```text
标准化作品标题
+ 年份（如果已知）
+ 季度（如果已知）
+ 剧集类型
+ 规范化集数
```

该标识不要求存在 Bangumi、TMDB 或其他网站 ID。

外部元数据 ID 后续可以作为辅助别名进行关联，但不是本地查重的必要条件。

### 优先使用父级作品上下文

当父级目录或未来的下载计划提供作品标题、年份和季度时，这些上下文优先于单个发布资源中的标题。

例如：

```python
parse_media_name(
    "[某字幕组] Unexpected Release Name - 03 [1080p]",
    series_title="示例动画",
    year=2024,
    season=1,
)
```

该资源会被识别为：

```text
示例动画
2024 年
第 1 季
第 3 集
```

而不会完全依赖字幕组发布标题重新判断作品。

在没有父级上下文时，解析器仍然可以从文件名推断作品信息，但会把结果标记为：

```text
context_source = inferred
confidence = low
```

从而让后续下载查重逻辑可以区别对待低可信结果。

### 发布版本不参与剧集身份

`v2`、`v10`、`PROPER` 和 `REPACK` 描述的是发布资源版本，而不是不同剧集。

因此：

```text
示例动画 - 03
示例动画 - 03v10
```

会生成相同的剧集标识。

画质升级、修正版替换等策略应与“是否为同一集”的判断分开实现。

## 解析示例

| 输入 | 结构化解析结果 |
| --- | --- |
| `Example.Show.S01E01-E03.1080p` | 普通第 1、2、3 集 |
| `Example Show - 12.5 [1080p]` | 普通第 12.5 集 |
| `Example Show SP01-SP03` | 特别篇第 1、2、3 集 |
| `Example Show OVA01` | OVA 第 1 集 |
| `[Show][10 - 总第76][WEB-DL]` | 季度内第 10 集，绝对第 76 集 |
| `Example Show [16v12]` | 第 16 集，发布修订版本为 12 |

## 误识别保护

新增反例处理，避免把以下内容错误识别为集数：

- 发布年份；
- 日期；
- `1080p`、`2160p` 等分辨率；
- 视频尺寸；
- CRC 或校验码；
- `OPUS`；
- 作品标题中原本存在的数字。

## 向后兼容

本 PR 不改变现有存储和 workflow 契约：

- `extract_episode()` 继续返回 `int | None`；
- 小数集和附加内容通过新的结构化接口返回；
- 现有媒体数据库整数集数字段保持不变；
- 不包含数据库迁移；
- 不修改数据刮削 workflow；
- 不修改下载器；
- 不修改下载计划执行流程；
- 不新增项目依赖。

## 性能

所有正则表达式都只在模块加载时编译一次。

在应用运行环境中使用典型发布标题进行本地基准测试（CPU为 Intel(R) Core(TM) Ultra
9 275HX），结果约为：

- 普通标题每条约 `27–37 μs`；
- 每秒可处理约 `27,000–37,000` 条标题；
- 对长度为 10,000 字符的异常输入，单条约 `4.6 ms`。

与索引站点 HTTP 请求、workflow 执行和下载器通信相比，解析开销可以忽略。

后续接入下载计划时，仍建议为合集范围设置合理上限，防止恶意标题产生过大的剧集集合。

## 测试

解析器测试补充了以下场景：

- 小数集；
- 多集范围；
- 合集范围；
- SP、OVA、OAD、ONA 等附加内容；
- 绝对集数；
- 多位发布修订版本；
- 父级上下文优先级；
- 文件名推断结果可信度；
- 标题归一化；
- 本地唯一键的确定性；
- 相同标题不同年份的标识隔离；
- 相同作品不同季度的标识隔离；
- 相同编号不同剧集类型的标识隔离；
- 日期、分辨率、校验码、编码名称和标题数字等反例。

已完成以下验证：

- 在带有真实 OpenCC 运行环境的应用容器中执行 129 个解析器测试，全部通过；
- `python -m compileall -q backend/app backend/tests`；
- `git diff --check`。

仓库 CI 可以继续执行标准 pytest 和 lint 检查。

## 后续下载计划查重

后续 PR 可以基于本次新增的剧集身份能力完成：

1. 在下载同步器中保留 indexer 返回的标题，而不是只保留磁力链接；
2. 使用下载计划或父级媒体条目提供作品上下文；
3. 将每个下载候选解析成本地剧集标识；
4. 持久化剧集占用记录及下载状态；
5. 使用数据库唯一约束实现原子占位；
6. 跳过已经处于占用、已提交或已完成状态的剧集；
7. 允许失败或取消的剧集重新下载；
8. 继续保留现有种子哈希查重，作为资源层面的第二层保护。

将解析器和唯一标识单独放在本 PR 中，可以先稳定并审查“如何判断同一集”的基础契约，再让它真正影响下载决策。